### PR TITLE
increase fallback date.now efficiency

### DIFF
--- a/lib/present-browser.js
+++ b/lib/present-browser.js
@@ -9,7 +9,7 @@ var present = (function () {
     }
   }
 
-  var dateNow = Date.now || function () { return +(new Date()); };
+  var dateNow = Date.now || function () { return new Date().getTime(); };
   var navigationStart = (performance.timing || {}).navigationStart || dateNow();
   return function () {
     return dateNow() - navigationStart;


### PR DESCRIPTION
`new Date().getTime()` is 30% faster than `+(new Date())` in chrome, ff, and safari
